### PR TITLE
feat: schema dependency support, non-opinionated pydantic schema validation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -122,8 +122,8 @@ py_schemax/
   - `RuleSetBasedValidation`: Main validation orchestrator class
   - `DEFAULT_RULESETS`: Default set of rules applied when no specific rules are specified
 - **Available Rules**:
-  - `PSX_VAL1` (`PydanticSchemaValidator`): Core schema validation using Pydantic models
-  - `PSX_VAL2` (`UniqueFQNValidator`): Cross-file FQN uniqueness validation
+  - `RV_SCHEMA` (`PydanticSchemaValidator`): Core schema validation using Pydantic models
+  - `RV_UNIQUE_FQN` (`UniqueFQNValidator`): Cross-file FQN uniqueness validation
 - **Rule Control**: CLI flags `--rule-apply` and `--rule-ignore` for selective rule execution
 - **Validation Flow**: File format validation always runs first, followed by selected schema validation rules
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Other similar alternatives,
 
 - **Extensible Schema Validation**: Validate JSON and YAML schema files against robust Pydantic models. Easily extend validation rules by updating model attributes—no complex configuration required.
 - **Unique FQN Validation**: Automatically detect and prevent duplicate Fully Qualified Names (FQNs) across multiple schema files in a single validation run.
-- **Modular Rule System**: Apply or ignore specific validation rules (`PSX_VAL1` for schema validation, `PSX_VAL2` for unique FQN validation) using CLI flags for flexible validation workflows.
+- **Modular Rule System**: Apply or ignore specific validation rules (`RV_SCHEMA` for schema validation, `RV_UNIQUE_FQN` for unique FQN validation) using CLI flags for flexible validation workflows.
 - **Clear, Structured Error Reporting**: Detailed error messages with precise [JSONPath](https://jsonpath.com/) style locations and readable formatting make troubleshooting straightforward.
 - **Flexible CLI Output & Controls**: Choose between text or JSON output, adjust verbosity, and control exit codes for seamless integration with CI/CD workflows.
 - **Multiple Configuration Options**: Support for configuration files (INI/TOML), environment variables, and command-line flags with clear precedence rules.
@@ -52,8 +52,8 @@ schemax validate --config my-config.toml schema.json    # Custom config file
 SCHEMAX_VALIDATE_OUTPUT_FORMAT=json schemax validate schema.json  # Environment variable
 
 # Control validation rules
-schemax validate --rule-apply PSX_VAL1 schema.json     # Only schema validation
-schemax validate --rule-ignore PSX_VAL2 schema.json    # Skip unique FQN validation
+schemax validate --rule-apply RV_SCHEMA schema.json     # Only schema validation
+schemax validate --rule-ignore RV_UNIQUE_FQN schema.json    # Skip unique FQN validation
 
 # See sample configuration files in the repository:
 # - sample.schemax.toml, sample.pyproject.toml, sample.env.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📋 py-schemax
 
-![license MIT](https://img.shields.io/badge/license-MIT-blue) [![codecov](https://codecov.io/gh/gauthamchettiar/py-schemax/branch/main/graph/badge.svg)](https://codecov.io/gh/gauthamchettiar/py-schemax) ![python3.10](https://img.shields.io/badge/python->=3.10-green)
+![license MIT](https://img.shields.io/badge/license-MIT-blue) [![codecov](https://codecov.io/gh/gauthamchettiar/py-schemax/branch/main/graph/badge.svg)](https://codecov.io/gh/gauthamchettiar/py-schemax) ![python3.10](https://img.shields.io/badge/python->=3.11-green)
 
 A powerful CLI tool for validating, managing, and maintaining data schema definitions using [Pydantic](https://github.com/pydantic/pydantic) models. This tool helps ensure your data schema files (JSON/YAML) conform to a standardized structure with comprehensive validation rules.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -31,20 +31,20 @@ schemax validate schema1.json schema2.yaml
 #   Error at $.fqn: Duplicate FQN 'com.example.users', already present at 'schema1.json'
 
 # To disable unique FQN validation:
-schemax validate --rule-ignore PSX_VAL2 schema1.json schema2.yaml
+schemax validate --rule-ignore RV_UNIQUE_FQN schema1.json schema2.yaml
 # Output:
 # ✅ schema1.json
 # ✅ schema2.yaml  (FQN conflict ignored)
 
 # To only run unique FQN validation (skip schema validation):
-schemax validate --rule-apply PSX_VAL2 schema1.json schema2.yaml
+schemax validate --rule-apply RV_UNIQUE_FQN schema1.json schema2.yaml
 
 # Common options
 schemax validate --verbose schema.json    # Show all results
 schemax validate --json schema.json       # JSON output
 schemax validate --fail-fast *.json       # Stop on first error
-schemax validate --rule-apply PSX_VAL1 schema.json  # Apply only specific rules
-schemax validate --rule-ignore PSX_VAL2 schema.json # Ignore specific rules
+schemax validate --rule-apply RV_SCHEMA schema.json  # Apply only specific rules
+schemax validate --rule-ignore RV_UNIQUE_FQN schema.json # Ignore specific rules
 ```
 
 ## Configuration
@@ -75,7 +75,7 @@ export SCHEMAX_VALIDATE_FAIL_MODE="never"
 | Output Format | `--json`, `--out` | `SCHEMAX_VALIDATE_OUTPUT_FORMAT` | `output_format` | `json`, `text` | `text` |
 | Verbosity | `--verbose`, `--silent` | `SCHEMAX_VALIDATE_OUTPUT_LEVEL` | `output_level` | `silent`, `quiet`, `verbose` | `quiet` |
 | Failure Mode | `--fail-fast`, `--fail-never` | `SCHEMAX_VALIDATE_FAIL_MODE` | `fail_mode` | `fast`, `never`, `after` | `after` |
-| Rule Control | `--rule-apply`, `--rule-ignore` | - | - | `PSX_VAL1`, `PSX_VAL2` | All rules applied |
+| Rule Control | `--rule-apply`, `--rule-ignore` | - | - | `RV_SCHEMA`, `RV_UNIQUE_FQN` | All rules applied |
 
 ## Schema File Format
 
@@ -313,23 +313,23 @@ py-schemax uses a modular validation system with different rule sets that can be
 
 | Rule ID | Description |
 |---------|-------------|
-| `PSX_VAL1` | **Pydantic Schema Validation** - Validates schema structure, data types, constraints, and required fields according to the defined Pydantic models |
-| `PSX_VAL2` | **Unique FQN Validation** - Ensures that Fully Qualified Names (FQNs) are unique across all validated schema files within a single validation run |
+| `RV_SCHEMA` | **Pydantic Schema Validation** - Validates schema structure, data types, constraints, and required fields according to the defined Pydantic models |
+| `RV_UNIQUE_FQN` | **Unique FQN Validation** - Ensures that Fully Qualified Names (FQNs) are unique across all validated schema files within a single validation run |
 
 #### Rule Control Options
 
 ```bash
 # Apply only specific rules (ignores default rule set)
-schemax validate --rule-apply PSX_VAL1 schema.json
+schemax validate --rule-apply RV_SCHEMA schema.json
 # Only runs Pydantic schema validation
 
 # Ignore specific rules (applies all other rules)
-schemax validate --rule-ignore PSX_VAL1 schema.json
+schemax validate --rule-ignore RV_SCHEMA schema.json
 # Skips Pydantic validation (currently would only validate file format)
 
 # Combine multiple rules (when more rules are available)
-schemax validate --rule-apply PSX_VAL1 --rule-apply PSX_VAL2 schema.json
-schemax validate --rule-ignore PSX_VAL1 --rule-ignore PSX_VAL2 schema.json
+schemax validate --rule-apply RV_SCHEMA --rule-apply RV_UNIQUE_FQN schema.json
+schemax validate --rule-ignore RV_SCHEMA --rule-ignore RV_UNIQUE_FQN schema.json
 
 # Rule precedence: --rule-apply takes precedence over defaults
 # If --rule-apply is specified, only those rules are applied
@@ -341,23 +341,23 @@ schemax validate --rule-ignore PSX_VAL1 --rule-ignore PSX_VAL2 schema.json
 ```bash
 # Default behavior (all rules applied)
 schemax validate schema.json
-# Runs: File format validation + PSX_VAL1 (Pydantic validation) + PSX_VAL2 (Unique FQN validation)
+# Runs: File format validation + RV_SCHEMA (Pydantic validation) + RV_UNIQUE_FQN (Unique FQN validation)
 
 # Apply only schema validation
-schemax validate --rule-apply PSX_VAL1 schema.json
-# Runs: File format validation + PSX_VAL1 only
+schemax validate --rule-apply RV_SCHEMA schema.json
+# Runs: File format validation + RV_SCHEMA only
 
 # Apply only unique FQN validation
-schemax validate --rule-apply PSX_VAL2 schema.json
-# Runs: File format validation + PSX_VAL2 only
+schemax validate --rule-apply RV_UNIQUE_FQN schema.json
+# Runs: File format validation + RV_UNIQUE_FQN only
 
 # Skip schema validation (validate only file format and unique FQN)
-schemax validate --rule-ignore PSX_VAL1 schema.json
-# Runs: File format validation + PSX_VAL2 only
+schemax validate --rule-ignore RV_SCHEMA schema.json
+# Runs: File format validation + RV_UNIQUE_FQN only
 
 # Skip unique FQN validation (validate only file format and schema)
-schemax validate --rule-ignore PSX_VAL2 schema.json
-# Runs: File format validation + PSX_VAL1 only
+schemax validate --rule-ignore RV_UNIQUE_FQN schema.json
+# Runs: File format validation + RV_SCHEMA only
 ```
 
 **Note**: File format validation (JSON/YAML parsing) always runs first regardless of rule settings. Rule control applies to the schema validation layer.
@@ -379,13 +379,13 @@ export SCHEMAX_VALIDATE_OUTPUT_FORMAT="text"
 schemax validate --json schema.json  # Uses JSON despite env var
 
 # Selective rule application with output control
-schemax validate --rule-apply PSX_VAL1 --json --verbose *.json
+schemax validate --rule-apply RV_SCHEMA --json --verbose *.json
 
 # Skip specific rules with fail-fast behavior
-schemax validate --rule-ignore PSX_VAL1 --fail-fast schemas/*.yaml
+schemax validate --rule-ignore RV_SCHEMA --fail-fast schemas/*.yaml
 
 # Complex combination: JSON output, verbose mode, custom rules, never fail
-schemax validate --json --verbose --rule-apply PSX_VAL1 --fail-never schemas/
+schemax validate --json --verbose --rule-apply RV_SCHEMA --fail-never schemas/
 ```
 
 ## Integration with CI/CD
@@ -478,12 +478,12 @@ schemax validate schema1.json schema2.json
 
 #### Missing FQN for Unique Validation
 ```bash
-schemax validate --rule-apply PSX_VAL2 incomplete_schema.json
+schemax validate --rule-apply RV_UNIQUE_FQN incomplete_schema.json
 # ❌ incomplete_schema.json
 #   Error at $.fqn: Duplicate fqn check is enabled but fqn field is missing
 ```
 
-**Solution:** When using unique FQN validation (PSX_VAL2), ensure all schema files have an `fqn` field defined.
+**Solution:** When using unique FQN validation (RV_UNIQUE_FQN), ensure all schema files have an `fqn` field defined.
 
 ### Performance Tips
 
@@ -527,6 +527,6 @@ schemax validate --json problematic_schema.json | jq '.'
 | `schemax validate --fail-never *.yaml` | Never exit with error code |
 | `schemax validate --silent file.json` | No output, only exit codes |
 | `schemax validate --config custom.toml *.json` | Use custom config file |
-| `schemax validate --rule-apply PSX_VAL1 file.json` | Apply only specific validation rules |
-| `schemax validate --rule-ignore PSX_VAL2 file.json` | Ignore specific validation rules |
+| `schemax validate --rule-apply RV_SCHEMA file.json` | Apply only specific validation rules |
+| `schemax validate --rule-ignore RV_UNIQUE_FQN file.json` | Ignore specific validation rules |
 | `find . -name "*.json" \| schemax validate` | Validate files from pipe |

--- a/py_schemax/cli.py
+++ b/py_schemax/cli.py
@@ -155,7 +155,9 @@ def main() -> None:
     help="Ignore validation rules, only specified rules will be ignored",
     envvar="SCHEMAX_VALIDATE_RULE_IGNORE",
 )
+@click.pass_context
 def validate(
+    ctx: click.Context,
     file_paths: List[str],
     output_format: str,
     use_json: bool,
@@ -219,15 +221,19 @@ def validate(
       SCHEMAX_VALIDATE_FAIL_MODE        Set default failure mode (fail_fast|fail_never|fail_after)
     """
     file_paths = accept_file_paths_as_stdin(file_paths)
-    config = Config()
-    config.set_output_format(output_format=output_format, use_json=use_json)
-    config.set_output_level(
+
+    default_map = ctx.default_map or {}
+    config = Config(
+        output_format=output_format,
+        use_json=use_json,
         output_level=output_level,
         output_level_verbose=output_level_verbose,
         output_level_silent=output_level_silent,
-    )
-    config.set_fail_mode(
-        fail_mode=fail_mode, fail_fast=fail_fast, fail_never=fail_never
+        fail_mode=fail_mode,
+        fail_fast=fail_fast,
+        fail_never=fail_never,
+        model_required_attributes=default_map.get("model_required_attributes"),
+        column_required_attributes=default_map.get("column_required_attributes"),
     )
 
     output = Output(config=config)

--- a/py_schemax/model.py
+++ b/py_schemax/model.py
@@ -1,0 +1,112 @@
+import typing
+from enum import Enum
+from typing import Annotated, Dict, List, Optional, Type, Union, Unpack
+
+from pydantic import Discriminator, Field, create_model
+
+from py_schemax.config import Config
+from py_schemax.schema.models import (
+    BaseDataType,
+    BooleanType,
+    DatasetSchema,
+    DateTimeType,
+    DateType,
+    FloatType,
+    IntegerType,
+    StringType,
+)
+
+
+class SupportedDataTypes(Enum):
+    string = StringType
+    integer = IntegerType
+    float = FloatType
+    boolean = BooleanType
+    date = DateType
+    datetime = DateTimeType
+
+
+@typing.no_type_check
+def __create_dynamic_data_type(
+    base_model: Type[BaseDataType], type_name: str, required_fields: List[str]
+) -> Type[BaseDataType]:
+    """Create a dynamic data type model with specified required fields."""
+    fields = {}
+    required_fields_set = set(required_fields or [])
+
+    for field_name, model_field in base_model.model_fields.items():
+        if field_name in required_fields_set:
+            # Make field required by removing default and setting ... (Ellipsis)
+            fields[field_name] = (
+                model_field.annotation,
+                Field(..., description=model_field.description),
+            )
+        else:
+            # Keep original field definition
+            fields[field_name] = (model_field.annotation, model_field)
+
+    return create_model(
+        f"Dynamic{type_name}",
+        __config__=base_model.model_config,
+        __base__=base_model,
+        **fields,
+    )
+
+
+def get_dynamic_data_types(config: Config) -> Dict[str, type[BaseDataType]]:
+    """Create dynamic data type models based on configuration."""
+    column_required_attributes = config.column_required_attributes or {}
+
+    dynamic_types = {}
+
+    for data_type in SupportedDataTypes:
+        base_model = data_type.value
+        required_fields = column_required_attributes.get(data_type.name, [])
+        dynamic_types[data_type.name] = __create_dynamic_data_type(
+            base_model, base_model.__name__, required_fields
+        )
+
+    return dynamic_types
+
+
+@typing.no_type_check
+def get_dynamic_dataset_schema(config: Config) -> type[DatasetSchema]:
+    dynamic_data_types = get_dynamic_data_types(config)
+
+    DynamicDataTypeUnion = Annotated[  # type: ignore [valid-type]
+        Union[tuple(dynamic_data_types.values())],
+        Discriminator("type"),
+    ]
+
+    fields = {}
+    required_fields = set(config.model_required_attributes or [])
+
+    for field_name, model_field in DatasetSchema.model_fields.items():
+        if field_name == "columns":
+            # Handle columns field specially to use dynamic types
+            if field_name in required_fields:
+                fields[field_name] = (
+                    List[DynamicDataTypeUnion],  # type: ignore [valid-type]
+                    Field(..., description=model_field.description),
+                )
+            else:
+                fields[field_name] = (
+                    Optional[List[DynamicDataTypeUnion]],  # type: ignore [valid-type]
+                    Field(default=None, description=model_field.description),
+                )
+        else:
+            # Handle other fields normally
+            if field_name in required_fields:
+                fields[field_name] = (
+                    model_field.annotation,
+                    Field(..., description=model_field.description),
+                )
+            else:
+                fields[field_name] = (model_field.annotation, model_field)
+
+    return create_model(
+        "DynamicDatasetSchema",
+        __config__=DatasetSchema.model_config,
+        __base__=DatasetSchema,
+        **fields,
+    )

--- a/py_schemax/rulesets.py
+++ b/py_schemax/rulesets.py
@@ -6,6 +6,8 @@ from py_schemax.config import Config
 from py_schemax.schema.validation import ValidationOutputSchema
 from py_schemax.utils import merge_validation_outputs
 from py_schemax.validator import (
+    DependentsSchemaValidator,
+    DependsOnSchemaValidator,
     FileValidator,
     PydanticSchemaValidator,
     UniqueFQNValidator,
@@ -15,9 +17,11 @@ from py_schemax.validator import (
 class ValidationRuleSetEnum(Enum):
     PSX_VAL1 = PydanticSchemaValidator
     PSX_VAL2 = UniqueFQNValidator
+    PSX_VAL3 = DependsOnSchemaValidator
+    PSX_VAL4 = DependentsSchemaValidator
 
 
-DEFAULT_RULESETS = (ValidationRuleSetEnum.PSX_VAL1, ValidationRuleSetEnum.PSX_VAL2)
+DEFAULT_RULESETS = (ValidationRuleSetEnum.PSX_VAL1,)
 
 
 class RuleSetBasedValidation:
@@ -43,24 +47,3 @@ class RuleSetBasedValidation:
                 return merge_validation_outputs(file_validator_output, validator_output)
 
         return file_validator_output
-
-
-# def validate_file_by_ruleset(
-#     config: Config,
-#     file_path: str | Path,
-#     apply_rules: list[ValidationRuleSetEnum],
-# ) -> ValidationOutputSchema:
-#     """Validate a file using the appropriate validator based on its extension."""
-#     file_validator = FileValidator(config)
-#     if (file_validator_output := file_validator.validate(file_path)).get(
-#         "valid", False
-#     ) is False:
-#         return file_validator_output
-#     for rule in apply_rules:
-#         validator = rule.value(config)
-#         if (
-#             validator_output := validator.validate(file_validator.validated_content or {}, str(file_path))
-#         ).get("valid", False) is False:
-#             return merge_validation_outputs(file_validator_output, validator_output)
-
-#     return file_validator_output

--- a/py_schemax/rulesets.py
+++ b/py_schemax/rulesets.py
@@ -15,13 +15,13 @@ from py_schemax.validator import (
 
 
 class ValidationRuleSetEnum(Enum):
-    PSX_VAL1 = PydanticSchemaValidator
-    PSX_VAL2 = UniqueFQNValidator
-    PSX_VAL3 = DependsOnSchemaValidator
-    PSX_VAL4 = DependentsSchemaValidator
+    RV_SCHEMA = PydanticSchemaValidator
+    RV_UNIQUE_FQN = UniqueFQNValidator
+    RV_DEPENDS_ON = DependsOnSchemaValidator
+    RV_DEPENDENTS = DependentsSchemaValidator
 
 
-DEFAULT_RULESETS = (ValidationRuleSetEnum.PSX_VAL1,)
+DEFAULT_RULESETS = (ValidationRuleSetEnum.RV_SCHEMA,)
 
 
 class RuleSetBasedValidation:

--- a/py_schemax/schema/dataset.py
+++ b/py_schemax/schema/dataset.py
@@ -157,3 +157,11 @@ class DatasetSchema(BaseModel):
         default=None,
         description="List of tags or keywords associated with the dataset for easier categorization and searchability",
     )
+    depends_on: Optional[List[str]] = Field(
+        default=None,
+        description="List of file paths that this dataset depends on",
+    )
+    dependents: Optional[List[str]] = Field(
+        default=None,
+        description="List of file paths that depend on this dataset",
+    )

--- a/py_schemax/schema/models.py
+++ b/py_schemax/schema/models.py
@@ -2,39 +2,22 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Discriminator, Field
 
-# Constants for runtime use
-DT_STRING = "string"
-DT_INTEGER = "integer"
-DT_FLOAT = "float"
-DT_BOOLEAN = "boolean"
-DT_DATE = "date"
-DT_DATETIME = "datetime"
-
-SUPPORTED_DATA_TYPES = [
-    DT_STRING,
-    DT_INTEGER,
-    DT_FLOAT,
-    DT_BOOLEAN,
-    DT_DATE,
-    DT_DATETIME,
-]
-
 
 class BaseDataType(BaseModel):
     model_config = {"extra": "forbid"}  # Reject extra fields
 
-    name: str = Field(
-        ..., description="Unique identifier for the column within the dataset"
+    name: Optional[str] = Field(
+        default=None, description="Unique identifier for the column within the dataset"
     )
-    unique: bool = Field(
+    unique: Optional[bool] = Field(
         default=False,
         description="Whether the column values must be unique across all rows in the dataset",
     )
-    primary_key: bool = Field(
+    primary_key: Optional[bool] = Field(
         default=False,
         description="Whether this column serves as the primary key for the dataset, uniquely identifying each row",
     )
-    nullable: bool = Field(
+    nullable: Optional[bool] = Field(
         default=True,
         description="Whether the column can contain null/None values. Set to False for required fields",
     )
@@ -101,7 +84,7 @@ class DateType(BaseDataType):
         description="Data type identifier for date-only columns (no time component)"
     )
     format: Optional[str] = Field(
-        default="YYYY-MM-DD",
+        default=None,
         description="Expected date format string using standard date format tokens",
     )
 
@@ -111,7 +94,7 @@ class DateTimeType(BaseDataType):
         description="Data type identifier for date and time columns with full timestamp support"
     )
     format: Optional[str] = Field(
-        default="YYYY-MM-DD HH:MM:SS",
+        default=None,
         description="Expected datetime format string using standard datetime format tokens",
     )
     timezone: Optional[str] = Field(
@@ -129,24 +112,24 @@ DataTypeUnion = Annotated[
 class DatasetSchema(BaseModel):
     model_config = {"extra": "forbid"}  # Reject extra fields
 
-    fqn: str = Field(
-        ...,
+    fqn: Optional[str] = Field(
+        default=None,
         description="Fully qualified name of the dataset schema, typically in the format 'namespace.dataset_name'",
     )
-    name: str = Field(
-        ...,
+    name: Optional[str] = Field(
+        default=None,
         description="Name identifying this dataset schema for reference and documentation purposes",
     )
     description: Optional[str] = Field(
         default=None,
         description="Comprehensive description of the dataset's purpose, content, and intended use cases",
     )
-    version: str = Field(
-        default="1.0",
+    version: Optional[str] = Field(
+        default=None,
         description="Schema version following semantic versioning to track schema evolution and compatibility",
     )
-    columns: List[DataTypeUnion] = Field(
-        ...,
+    columns: Optional[List[DataTypeUnion]] = Field(
+        default=None,
         description="Complete list of column definitions that make up the dataset structure, each with its own validation rules",
     )
     metadata: Optional[Dict[str, Any]] = Field(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,8 +56,6 @@ def invalid_schemas(invalid_schemas_dir) -> dict[str, Path]:
     """Return the path to a complex YAML schema file."""
     return {
         "invalid_columns": invalid_schemas_dir / "invalid_columns.yaml",
-        "invalid_missing_columns": invalid_schemas_dir / "invalid_missing_columns.yaml",
-        "invalid_missing_name": invalid_schemas_dir / "invalid_missing_name.json",
         "invalid_types": invalid_schemas_dir / "invalid_types.json",
         "invalid_unsupported_format": invalid_schemas_dir
         / "invalid_unsupported_format.txt",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,25 @@ def invalid_schemas_dir(fixtures_dir) -> Path:
 
 
 @pytest.fixture
+def dependent_schemas_dir(fixtures_dir) -> Path:
+    """Return the path to the dependent schemas fixtures directory."""
+    return fixtures_dir / "dependent_schemas"
+
+
+@pytest.fixture
+def dependent_schemas(dependent_schemas_dir) -> dict[str, Path]:
+    """Return the path to the dependent schemas fixtures directory."""
+    return {
+        "valid_dependency_a": dependent_schemas_dir / "valid_dependency_a.yaml",
+        "valid_dependency_b": dependent_schemas_dir / "valid_dependency_b.yaml",
+        "valid_dependency_c": dependent_schemas_dir / "valid_dependency_c.yaml",
+        "invalid_dependency_a": dependent_schemas_dir / "invalid_dependency_a.yaml",
+        "invalid_dependency_b": dependent_schemas_dir / "invalid_dependency_b.yaml",
+        "invalid_dependency_c": dependent_schemas_dir / "invalid_dependency_c.yaml",
+    }
+
+
+@pytest.fixture
 def valid_schemas(valid_schemas_dir) -> dict[str, Path]:
     """Return the path to a simple valid YAML schema file."""
     return {
@@ -66,6 +85,8 @@ def dataset_with_optional_fields(dataset_with_reqd_fields):
         "description": "This is a test dataset schema",
         "tags": ["test", "example"],
         "metadata": {"source": "Generated for testing", "frequency": "daily"},
+        "depends_on": ["abc"],
+        "dependents": ["def"],
     }
 
 

--- a/tests/fixtures/dependent_schemas/invalid_dependency_a.yaml
+++ b/tests/fixtures/dependent_schemas/invalid_dependency_a.yaml
@@ -1,0 +1,10 @@
+name: invalid_dependency_a
+fqn: com.example.InvalidDependencyA
+description: This is an invalid dependency schema A.
+depends_on:
+  - tests/fixtures/dependent_schemas/valid_dependency_b.yaml
+  - tests/fixtures/dependent_schemas/valid_dependency_c.yaml
+  - tests/fixtures/dependent_schemas/invalid_dependency_b.yaml
+dependents:
+  - tests/fixtures/dependent_schemas/invalid_dependency_b.yaml
+  - tests/fixtures/dependent_schemas/invalid_dependency_c.yaml

--- a/tests/fixtures/dependent_schemas/invalid_dependency_a.yaml
+++ b/tests/fixtures/dependent_schemas/invalid_dependency_a.yaml
@@ -1,6 +1,7 @@
 name: invalid_dependency_a
 fqn: com.example.InvalidDependencyA
 description: This is an invalid dependency schema A.
+columns: []
 depends_on:
   - tests/fixtures/dependent_schemas/valid_dependency_b.yaml
   - tests/fixtures/dependent_schemas/valid_dependency_c.yaml

--- a/tests/fixtures/dependent_schemas/invalid_dependency_b.yaml
+++ b/tests/fixtures/dependent_schemas/invalid_dependency_b.yaml
@@ -1,0 +1,8 @@
+name: invalid_dependency_b
+fqn: com.example.InvalidDependencyB
+description: This is an invalid dependency schema B.
+depends_on:
+  - tests/fixtures/dependent_schemas/valid_dependency_a.yaml
+  - tests/fixtures/dependent_schemas/invalid_dependency_c.yaml
+dependents:
+  - tests/fixtures/dependent_schemas/invalid_dependency_a.yaml

--- a/tests/fixtures/dependent_schemas/invalid_dependency_b.yaml
+++ b/tests/fixtures/dependent_schemas/invalid_dependency_b.yaml
@@ -1,6 +1,7 @@
 name: invalid_dependency_b
 fqn: com.example.InvalidDependencyB
 description: This is an invalid dependency schema B.
+columns: []
 depends_on:
   - tests/fixtures/dependent_schemas/valid_dependency_a.yaml
   - tests/fixtures/dependent_schemas/invalid_dependency_c.yaml

--- a/tests/fixtures/dependent_schemas/invalid_dependency_c.yaml
+++ b/tests/fixtures/dependent_schemas/invalid_dependency_c.yaml
@@ -1,6 +1,7 @@
 name: invalid_dependency_c
 fqn: com.example.InvalidDependencyC
 description: This is an invalid dependency schema C.
+columns: []
 depends_on:
   - tests/fixtures/dependent_schemas/invalid_dependency_a.yaml
   - tests/fixtures/dependent_schemas/invalid_dependency_c.yaml

--- a/tests/fixtures/dependent_schemas/invalid_dependency_c.yaml
+++ b/tests/fixtures/dependent_schemas/invalid_dependency_c.yaml
@@ -1,0 +1,8 @@
+name: invalid_dependency_c
+fqn: com.example.InvalidDependencyC
+description: This is an invalid dependency schema C.
+depends_on:
+  - tests/fixtures/dependent_schemas/invalid_dependency_a.yaml
+  - tests/fixtures/dependent_schemas/invalid_dependency_c.yaml
+dependents:
+  - tests/fixtures/dependent_schemas/invalid_dependency_b.yaml

--- a/tests/fixtures/dependent_schemas/valid_dependency_a.yaml
+++ b/tests/fixtures/dependent_schemas/valid_dependency_a.yaml
@@ -1,6 +1,7 @@
 name: valid_dependency_a
 fqn: com.example.ValidDependencyA
 description: This is a valid dependency schema A.
+columns: []
 depends_on:
   - tests/fixtures/dependent_schemas/valid_dependency_b.yaml
   - tests/fixtures/dependent_schemas/valid_dependency_c.yaml

--- a/tests/fixtures/dependent_schemas/valid_dependency_a.yaml
+++ b/tests/fixtures/dependent_schemas/valid_dependency_a.yaml
@@ -1,0 +1,6 @@
+name: valid_dependency_a
+fqn: com.example.ValidDependencyA
+description: This is a valid dependency schema A.
+depends_on:
+  - tests/fixtures/dependent_schemas/valid_dependency_b.yaml
+  - tests/fixtures/dependent_schemas/valid_dependency_c.yaml

--- a/tests/fixtures/dependent_schemas/valid_dependency_b.yaml
+++ b/tests/fixtures/dependent_schemas/valid_dependency_b.yaml
@@ -1,5 +1,6 @@
 name: valid_dependency_b
 fqn: com.example.ValidDependencyB
 description: This is a valid dependency schema B.
+columns: []
 depends_on:
   - tests/fixtures/dependent_schemas/valid_dependency_c.yaml

--- a/tests/fixtures/dependent_schemas/valid_dependency_b.yaml
+++ b/tests/fixtures/dependent_schemas/valid_dependency_b.yaml
@@ -1,0 +1,5 @@
+name: valid_dependency_b
+fqn: com.example.ValidDependencyB
+description: This is a valid dependency schema B.
+depends_on:
+  - tests/fixtures/dependent_schemas/valid_dependency_c.yaml

--- a/tests/fixtures/dependent_schemas/valid_dependency_c.yaml
+++ b/tests/fixtures/dependent_schemas/valid_dependency_c.yaml
@@ -1,0 +1,3 @@
+name: valid_dependency_c
+fqn: com.example.ValidDependencyC
+description: This is a valid dependency schema C.

--- a/tests/fixtures/dependent_schemas/valid_dependency_c.yaml
+++ b/tests/fixtures/dependent_schemas/valid_dependency_c.yaml
@@ -1,3 +1,4 @@
 name: valid_dependency_c
 fqn: com.example.ValidDependencyC
 description: This is a valid dependency schema C.
+columns: []

--- a/tests/fixtures/invalid_schemas/invalid_missing_columns.yaml
+++ b/tests/fixtures/invalid_schemas/invalid_missing_columns.yaml
@@ -1,5 +1,0 @@
-name: "Missing Columns"
-fqn: "tests.fixtures.invalid_schemas.invalid_missing_columns"
-description: "Schema missing required columns field"
-version: "1.0"
-# Missing columns field

--- a/tests/fixtures/invalid_schemas/invalid_missing_name.json
+++ b/tests/fixtures/invalid_schemas/invalid_missing_name.json
@@ -1,9 +1,0 @@
-{
-  "fqn": "tests.fixtures.invalid_schemas.invalid_missing_name",
-  "columns": [
-    {
-      "name": "test_field",
-      "type": "string"
-    }
-  ]
-}

--- a/tests/test_cmd_validate.py
+++ b/tests/test_cmd_validate.py
@@ -902,7 +902,7 @@ class TestUniqueFQNValidation:
         args = [
             str(valid_schemas["valid_simple_schema"]),
             str(valid_schemas["valid_simple_schema"]),
-        ] + ["--verbose"]
+        ] + ["--verbose", "--rule-apply", "PSX_VAL2"]
         result = runner.invoke(
             validate, _with_output_format_option(args, output_format=output_format)
         )
@@ -913,4 +913,44 @@ class TestUniqueFQNValidation:
             expected_exit_code=1,
             expected_ok_count=1,
             expected_error_count=1,
+        )
+
+
+class TestDependenciesValidation:
+    @pytest.mark.parametrize("output_format", ["text", "json"])
+    def test_dependencies_validation_depends_on(self, dependent_schemas, output_format):
+        runner = CliRunner()
+        args = [str(ds) for ds in dependent_schemas.values()] + [
+            "--verbose",
+            "--rule-apply",
+            "PSX_VAL3",
+        ]
+        result = runner.invoke(
+            validate, _with_output_format_option(args, output_format=output_format)
+        )
+        _validate_stdout(
+            result,
+            output_format=output_format,
+            expected_exit_code=1,
+            expected_ok_count=5,
+            expected_error_count=1,
+        )
+
+    @pytest.mark.parametrize("output_format", ["text", "json"])
+    def test_dependencies_validation_dependents(self, dependent_schemas, output_format):
+        runner = CliRunner()
+        args = [str(ds) for ds in dependent_schemas.values()] + [
+            "--verbose",
+            "--rule-apply",
+            "PSX_VAL4",
+        ]
+        result = runner.invoke(
+            validate, _with_output_format_option(args, output_format=output_format)
+        )
+        _validate_stdout(
+            result,
+            output_format=output_format,
+            expected_exit_code=1,
+            expected_ok_count=4,
+            expected_error_count=2,
         )

--- a/tests/test_pydantic_schema.py
+++ b/tests/test_pydantic_schema.py
@@ -1,6 +1,6 @@
 import pytest
 
-from py_schemax.schema.dataset import DatasetSchema, DataTypeUnion
+from py_schemax.schema.models import DatasetSchema, DataTypeUnion
 
 
 def test_dataset_schema_with_required_fields_only(dataset_with_reqd_fields):
@@ -52,6 +52,7 @@ def test_dataset_schema_model_dump_field_count(dataset_with_optional_fields):
 def test_string_column_type(dataset_with_columns):
     """Test string column type validation and properties."""
     dataset_schema = DatasetSchema(**dataset_with_columns)
+    assert dataset_schema.columns is not None
     string_column = dataset_schema.columns[0]
 
     assert string_column.name == "column1"
@@ -64,6 +65,7 @@ def test_string_column_type(dataset_with_columns):
 def test_integer_column_type(dataset_with_columns):
     """Test integer column type validation and properties."""
     dataset_schema = DatasetSchema(**dataset_with_columns)
+    assert dataset_schema.columns is not None
     integer_column = dataset_schema.columns[1]
 
     assert integer_column.name == "column2"
@@ -75,6 +77,7 @@ def test_integer_column_type(dataset_with_columns):
 def test_float_column_type(dataset_with_columns):
     """Test float column type validation and properties."""
     dataset_schema = DatasetSchema(**dataset_with_columns)
+    assert dataset_schema.columns is not None
     float_column = dataset_schema.columns[2]
 
     assert float_column.name == "column3"
@@ -87,6 +90,7 @@ def test_float_column_type(dataset_with_columns):
 def test_boolean_column_type(dataset_with_columns):
     """Test boolean column type validation and properties."""
     dataset_schema = DatasetSchema(**dataset_with_columns)
+    assert dataset_schema.columns is not None
     boolean_column = dataset_schema.columns[3]
 
     assert boolean_column.name == "column4"
@@ -96,6 +100,7 @@ def test_boolean_column_type(dataset_with_columns):
 def test_date_column_type(dataset_with_columns):
     """Test date column type validation and properties."""
     dataset_schema = DatasetSchema(**dataset_with_columns)
+    assert dataset_schema.columns is not None
     date_column = dataset_schema.columns[4]
 
     assert date_column.name == "column5"
@@ -106,6 +111,7 @@ def test_date_column_type(dataset_with_columns):
 def test_datetime_column_type(dataset_with_columns):
     """Test datetime column type validation and properties."""
     dataset_schema = DatasetSchema(**dataset_with_columns)
+    assert dataset_schema.columns is not None
     datetime_column = dataset_schema.columns[5]
 
     assert datetime_column.name == "column6"
@@ -118,6 +124,7 @@ def test_column_common_default_properties(dataset_with_columns):
     """Test that all columns have correct default values for common properties."""
     dataset_schema = DatasetSchema(**dataset_with_columns)
 
+    assert dataset_schema.columns is not None
     for column in dataset_schema.columns:
         assert column.unique is False
         assert column.nullable is True
@@ -129,6 +136,7 @@ def test_column_count_and_types(dataset_with_columns):
     """Test that the correct number and types of columns are present."""
     dataset_schema = DatasetSchema(**dataset_with_columns)
 
+    assert dataset_schema.columns is not None
     assert len(dataset_schema.columns) == 6
 
     column_types = [column.type for column in dataset_schema.columns]
@@ -143,6 +151,7 @@ def test_column_model_dump_field_counts(dataset_with_columns):
         5  # name, type, unique, nullable, primary_key, description
     )
 
+    assert dataset_schema.columns is not None
     # String type: common fields + max_length, min_length, pattern, type = 5 + 4 = 9
     assert dataset_schema.columns[0].type == "string"
     assert len(dataset_schema.columns[0].model_dump()) == common_column_fields_count + 4

--- a/tests/test_pydantic_schema.py
+++ b/tests/test_pydantic_schema.py
@@ -17,6 +17,8 @@ def test_dataset_schema_with_required_fields_only(dataset_with_reqd_fields):
     assert dataset_schema.description is None
     assert dataset_schema.tags is None
     assert dataset_schema.metadata is None
+    assert dataset_schema.depends_on is None
+    assert dataset_schema.dependents is None
 
 
 def test_dataset_schema_with_optional_fields(dataset_with_optional_fields):
@@ -36,13 +38,15 @@ def test_dataset_schema_with_optional_fields(dataset_with_optional_fields):
         "source": "Generated for testing",
         "frequency": "daily",
     }
+    assert dataset_schema.depends_on == ["abc"]
+    assert dataset_schema.dependents == ["def"]
 
 
 def test_dataset_schema_model_dump_field_count(dataset_with_optional_fields):
     """Test that model_dump() returns expected number of fields."""
     dataset_schema = DatasetSchema(**dataset_with_optional_fields)
     # any extra fields added to schema must be added to test, otherwise below assertion will fail
-    assert len(dataset_schema.model_dump()) == 7
+    assert len(dataset_schema.model_dump()) == 9
 
 
 def test_string_column_type(dataset_with_columns):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,7 +1,7 @@
 import pytest
 
 from py_schemax.config import Config
-from py_schemax.schema.dataset import SUPPORTED_DATA_TYPES
+from py_schemax.model import SupportedDataTypes
 from py_schemax.validator import (
     DependentsSchemaValidator,
     DependsOnSchemaValidator,
@@ -109,7 +109,7 @@ class TestPydanticValidationErrors:
             == "invalid attribute 'extra_field2' provided"
         )
 
-    @pytest.mark.parametrize("data_type", SUPPORTED_DATA_TYPES)
+    @pytest.mark.parametrize("data_type", SupportedDataTypes.__members__.keys())
     def test_extra_fields_in_columns(self, data_type: str):
         inp = {
             "name": "Test Dataset",
@@ -138,7 +138,9 @@ class TestPydanticValidationErrors:
             "name": "Test Dataset",
             "description": "This dataset is missing required fields.",
         }
-        psv = PydanticSchemaValidator(Config())
+        psv = PydanticSchemaValidator(
+            Config(model_required_attributes=["fqn", "columns"])
+        )
         result = psv.validate(inp, "")
         assert result["valid"] is False
         assert result["error_count"] == 2
@@ -147,7 +149,7 @@ class TestPydanticValidationErrors:
         assert result["errors"][1]["error_at"] == "$.columns"
         assert result["errors"][1]["message"] == "'columns' attribute missing"
 
-    @pytest.mark.parametrize("data_type", SUPPORTED_DATA_TYPES)
+    @pytest.mark.parametrize("data_type", SupportedDataTypes.__members__.keys())
     def test_missing_fields_in_columns(self, data_type: str):
         inp = {
             "name": "Test Dataset",
@@ -162,7 +164,9 @@ class TestPydanticValidationErrors:
                 },
             ],
         }
-        psv = PydanticSchemaValidator(Config())
+        psv = PydanticSchemaValidator(
+            Config(column_required_attributes={data_type: ["name", "type"]})
+        )
         result = psv.validate(inp, "")
         assert result["valid"] is False
         assert result["error_count"] == 2

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -496,7 +496,7 @@ class TestDependencyValidator:
             "name": "Invalid Dependency",
             "description": "This is an invalid dependency schema.",
             "depends_on": [
-                "tests/fixtures/dependent_schemas/valid_dependency_b.yaml"
+                "tests/fixtures/dependent_schemas/valid_dependency_b.yaml",
                 "non_existent_file.yaml",
             ],
             "dependents": [

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3,6 +3,8 @@ import pytest
 from py_schemax.config import Config
 from py_schemax.schema.dataset import SUPPORTED_DATA_TYPES
 from py_schemax.validator import (
+    DependentsSchemaValidator,
+    DependsOnSchemaValidator,
     FileValidator,
     PydanticSchemaValidator,
     UniqueFQNValidator,
@@ -406,5 +408,137 @@ class TestUniqueFQNValidatorErrors:
         assert result["errors"][0]["error_at"] == "$.fqn"
         assert (
             result["errors"][0]["message"]
-            == "Duplicate fqn check is enabled but fqn field is missing"
+            == "Duplicate fqn check is enabled but fqn field is missing or invalid"
         )
+
+
+class TestDependencyValidator:
+    def test_valid_dependency_depends_on(self, dependent_schemas):
+        fv = FileValidator(Config())
+        dv = DependsOnSchemaValidator(Config())
+
+        for schema_file in [
+            dependent_schemas["valid_dependency_a"],
+            dependent_schemas["valid_dependency_b"],
+            dependent_schemas["valid_dependency_c"],
+        ]:
+            fv.validate(str(schema_file))
+            assert fv.validated_content is not None
+
+            result = dv.validate(fv.validated_content, str(schema_file))
+            assert result["valid"] is True
+
+    def test_invalid_circular_dependency_depends_on(self, dependent_schemas):
+        fv = FileValidator(Config())
+        dv = DependsOnSchemaValidator(Config())
+
+        fv.validate(str(dependent_schemas["invalid_dependency_a"]))
+        assert fv.validated_content is not None
+        result = dv.validate(
+            fv.validated_content, str(dependent_schemas["invalid_dependency_a"])
+        )
+        assert result["valid"] is True
+
+        fv.validate(str(dependent_schemas["invalid_dependency_b"]))
+        assert fv.validated_content is not None
+        result = dv.validate(
+            fv.validated_content, str(dependent_schemas["invalid_dependency_b"])
+        )
+        assert result["valid"] is True
+
+        fv.validate(str(dependent_schemas["invalid_dependency_c"]))
+        assert fv.validated_content is not None
+        result = dv.validate(
+            fv.validated_content, str(dependent_schemas["invalid_dependency_c"])
+        )
+        assert result["valid"] is False
+        assert result["errors"][0]["type"] == "circular_dependency_detected"
+
+    def test_valid_dependency_dependents(self, dependent_schemas):
+        fv = FileValidator(Config())
+        dv = DependentsSchemaValidator(Config())
+
+        for schema_file in [
+            dependent_schemas["valid_dependency_a"],
+            dependent_schemas["valid_dependency_b"],
+            dependent_schemas["valid_dependency_c"],
+        ]:
+            fv.validate(str(schema_file))
+            assert fv.validated_content is not None
+
+            result = dv.validate(fv.validated_content, str(schema_file))
+            assert result["valid"] is True
+
+    def test_invalid_circular_dependency_dependents(self, dependent_schemas):
+        fv = FileValidator(Config())
+        dv = DependentsSchemaValidator(Config())
+
+        fv.validate(str(dependent_schemas["invalid_dependency_a"]))
+        assert fv.validated_content is not None
+        result = dv.validate(
+            fv.validated_content, str(dependent_schemas["invalid_dependency_a"])
+        )
+        assert result["valid"] is True
+
+        fv.validate(str(dependent_schemas["invalid_dependency_b"]))
+        assert fv.validated_content is not None
+        result = dv.validate(
+            fv.validated_content, str(dependent_schemas["invalid_dependency_b"])
+        )
+        assert result["valid"] is False
+
+    def test_invalid_file_not_present(self):
+        input = {
+            "name": "Invalid Dependency",
+            "description": "This is an invalid dependency schema.",
+            "depends_on": [
+                "tests/fixtures/dependent_schemas/valid_dependency_b.yaml"
+                "non_existent_file.yaml",
+            ],
+            "dependents": [
+                "tests/fixtures/dependent_schemas/valid_dependency_c.yaml",
+                "non_existent_file.yaml",
+            ],
+        }
+        dv1 = DependsOnSchemaValidator(Config())
+        result = dv1.validate(input, "")
+        assert result["valid"] is False
+        assert result["errors"][0]["type"] == "dependent_file_not_found"
+
+        dv2 = DependentsSchemaValidator(Config())
+        result = dv2.validate(input, "")
+        assert result["valid"] is False
+        assert result["errors"][0]["type"] == "dependent_file_not_found"
+
+    def test_invalid_field(self):
+        inputs = [
+            {
+                "name": "Invalid Field",
+                "depends_on": "tests/fixtures/dependent_schemas/valid_dependency_b.yaml",
+                "dependents": [
+                    1,
+                    "tests/fixtures/dependent_schemas/valid_dependency_b.yaml",
+                ],
+            },
+            {
+                "name": "Invalid Field 2",
+                "depends_on": [
+                    ["tests/fixtures/dependent_schemas/valid_dependency_b.yaml"]
+                ],
+                "dependents": [
+                    1,
+                    "tests/fixtures/dependent_schemas/valid_dependency_b.yaml",
+                ],
+            },
+        ]
+        dv1 = DependsOnSchemaValidator(Config())
+        for input in inputs:
+            result = dv1.validate(input, "")
+            assert result["valid"] is False
+            assert result["errors"][0]["type"] == "invalid_type"
+
+        dv2 = DependentsSchemaValidator(Config())
+        for input in inputs:
+            result = dv2.validate(input, "")
+            assert result["valid"] is False
+            assert result["errors"][0]["type"] == "invalid_type"


### PR DESCRIPTION
- schema dependency support : 
  - a schema can depend on another schema using depends_on and dependents fields
  - when any of them is added, all file_paths provided in the list must be present
  - if any circular dependencies are detected, it would error out for the script
- changed validation ruleset names to be more meaningful - PSX_VAL1 -> RV_SCHEMA & PSX_VAL2 -> RV_UNIQUE_FQN
- made all pydantic fields optional for a more non-opinionated approach,
- any required field enforcement can be done using config file
- enhanced config to accept all config during init, also separately